### PR TITLE
Changed EG website to EG github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Vim files for Earl Grey
 =======================
 
 This repository contains Vim runtime files for the Earl Grey programming
-language ([website](http://earl-grey.io)).
+language ([website](https://github.com/breuleux/earl-grey)).
 
 At present, only syntax highlighting is supported, but indent and ftplugin
 files are on the way.


### PR DESCRIPTION
EG website is broken, see [this issue](https://github.com/breuleux/earl-grey/issues/43)